### PR TITLE
Rector yaml basic

### DIFF
--- a/config/set/drupal/global_function_calls.yaml
+++ b/config/set/drupal/global_function_calls.yaml
@@ -1,0 +1,46 @@
+services:
+    DS\DrupalFixer\Rector\D80\TransformGlobalFunctionsRector:
+        drupal_set_message:
+            replacementType: static
+            static:
+                class: Drupal
+                factoryMethod: messenger
+                instanceMethod: addMessage
+        file_unmanaged_copy:
+            replacementType: static
+            static:
+                class: Drupal
+                factoryMethod: service
+                factoryMethodParams: 
+                    - file_system
+                instanceMethod: copy
+        taxonomy_term_load:
+            replacementType: static
+            static:
+                class: Drupal
+                factoryMethod: entityTypeManager
+                nextMethod:
+                    methodName: getStorage
+                    methodParams:
+                        - taxonomy_term
+                instanceMethod: load
+        node_load:
+            replacementType: static
+            static:
+                class: Drupal
+                factoryMethod: entityTypeManager
+                nextMethod:
+                    methodName: getStorage
+                    methodParams:
+                        - node
+                instanceMethod: load
+        user_load:
+            replacementType: static
+            static:
+                class: Drupal
+                factoryMethod: entityTypeManager
+                nextMethod:
+                    methodName: getStorage
+                    methodParams:
+                        - user
+                instanceMethod: load                

--- a/rector.yaml
+++ b/rector.yaml
@@ -2,5 +2,5 @@ imports:
     - { resource: 'config/set/drupal/global_function_calls.yaml' }
 parameters:
     autoload_paths:
-        - '../../docker-projects/d8d2/web/core/'
-        - '../../docker-projects/d8d2/web/modules/custom/diagnostic_report'
+        - 'path_to/drupal_project/to_be/checked/drupal/core/'
+        - 'path_to/drupal_project/to_be/checked/custom/custom_code/'

--- a/rector.yaml
+++ b/rector.yaml
@@ -1,0 +1,18 @@
+services:
+    DS\DrupalFixer\Rector\D80\TransformGlobalFunctionsRector:
+        drupal_set_message:
+            replacementType: static
+            static:
+                class: Drupal
+                factoryMethod: messenger
+                instanceMethod: addMessage
+        db_select:
+            replacementType: static
+            static:
+                class: Drupal
+                factoryMethod: database
+                instanceMethod: insert
+parameters:
+    autoload_paths:
+        - 'path_to/drupal_project/to_be/checked/drupal/core/'
+        - 'path_to/drupal_project/to_be/checked/drupal/web/modules/custom/my_module'

--- a/rector.yaml
+++ b/rector.yaml
@@ -1,18 +1,6 @@
-services:
-    DS\DrupalFixer\Rector\D80\TransformGlobalFunctionsRector:
-        drupal_set_message:
-            replacementType: static
-            static:
-                class: Drupal
-                factoryMethod: messenger
-                instanceMethod: addMessage
-        db_select:
-            replacementType: static
-            static:
-                class: Drupal
-                factoryMethod: database
-                instanceMethod: insert
+imports:
+    - { resource: 'config/set/drupal/global_function_calls.yaml' }
 parameters:
     autoload_paths:
-        - 'path_to/drupal_project/to_be/checked/drupal/core/'
-        - 'path_to/drupal_project/to_be/checked/drupal/web/modules/custom/my_module'
+        - '../../docker-projects/d8d2/web/core/'
+        - '../../docker-projects/d8d2/web/modules/custom/diagnostic_report'

--- a/src/Rector/D80/TransformGlobalFunctionsRector.php
+++ b/src/Rector/D80/TransformGlobalFunctionsRector.php
@@ -139,8 +139,8 @@ final class TransformGlobalFunctionsRector extends AbstractRector
         $node = $this->createStaticCall($configuration['class'], $configuration['factoryMethod'], $factoryMethodParams);
         $nextMethodConfigurations = isset($configuration['nextMethod']) ? $configuration['nextMethod'] : '' ;
 
-        while (!empty($nextMethodConfigurations)){
-            $node = $this->createMethodCall( $node, $nextMethodConfigurations['methodName'], $nextMethodConfigurations['methodParams']);
+        while (!empty($nextMethodConfigurations)) {
+            $node = $this->createMethodCall($node, $nextMethodConfigurations['methodName'], $nextMethodConfigurations['methodParams']);
             $nextMethodConfigurations = isset($nextMethodConfigurations['nextMethod']) ? $nextMethodConfigurations['nextMethod'] : '' ;
         }
 


### PR DESCRIPTION
Updated rector.yaml to support few new kinds of functions and added related php logic.
- If some methods have longer method chaining, those can be handled now.
` \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($id);`
- Factory method and other methods in chain can be provided with parameters from yaml file. (direct 
values e.g. integers, strings etc are possible but variables are not supported) 
`\Drupal::service('file_system')->copy($source, $destination);`
- Main rector (rector.yaml) file will include reference to all rectors which will be added to this source in future.
- Main rector file has sample autoload paths for drupal core and custom code under observation. These paths will be set according to each project. 